### PR TITLE
Added collapse section with exemption article

### DIFF
--- a/docassemble/MLHObjectionToGarnishment/data/questions/garnishmentobjection.yml
+++ b/docassemble/MLHObjectionToGarnishment/data/questions/garnishmentobjection.yml
@@ -569,9 +569,19 @@ fields:
 id: is_money_exempt
 question: |
   Exempt money
+subquestion: |
+  ${ collapse_template(exempt_income_article) }
 fields:
   - Are you objecting because you think the money being garnished is exempt (can't be garnished)?: is_money_exempt
     datatype: yesnoradio
+---
+template: exempt_income_article
+subject: |
+  How do I know if money is exempt from garnishment?
+content: |
+  Some assets and income can't be garnished because they are protected by law. 
+  
+  To learn what money is protected, please read [Income Protected from Garnishment](https://michiganlegalhelp.org/resources/money-debt-and-consumer-issues/income-protected-from-garnishment).
 ---
 id: in_process_bankruptcy
 question: |


### PR DESCRIPTION
Fixed #61 

- Added new collapse_template help text section with link to article about exempt income (see images).

<img width="899" height="621" alt="Screenshot 2026-05-14 at 4 48 28 PM" src="https://github.com/user-attachments/assets/a211db61-768c-403a-a062-14c4ad248b36" />
<img width="904" height="825" alt="Screenshot 2026-05-14 at 4 48 40 PM" src="https://github.com/user-attachments/assets/2696da45-24d6-4106-b5a4-4f5c3df7aa18" />