### PR TITLE
Added additional invalidate lines to periodic_garnishment_reset block

### DIFF
--- a/docassemble/MLHObjectionToGarnishment/data/questions/garnishmentobjection.yml
+++ b/docassemble/MLHObjectionToGarnishment/data/questions/garnishmentobjection.yml
@@ -396,7 +396,21 @@ code: |
       invalidate('attach_installment_order')
 
     elif not is_periodic_garnishment:
-      pass
+      ## has_installment_payment_interview_order ##
+      undefine('has_installment_payment_interview_order')
+      invalidate('has_installment_payment')
+      invalidate('is_current')
+      invalidate('not_current_objection')
+      invalidate('already_at_maximum')
+      ## installment_payment_interview_order ##
+      undefine('installment_payment_interview_order')
+      invalidate('installment_order_date')
+      invalidate('court_ordered')
+      invalidate('corrected_court_ordered')
+      invalidate('installment_case_number')
+      invalidate('is_same_case_number')
+      invalidate('installment_case_number')
+      invalidate('attach_installment_order')
 
   periodic_garnishment_reset = True
 ---


### PR DESCRIPTION
Fixes #68 

- Added additional invalidate lines to the periodic_garnishment_reset block. This successfully removes edit controls for variables associated with the `has_installment_payment_interview_order` and `installment_payment_interview_order` blocks when needed.